### PR TITLE
faet: implement caching using Hazelcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ BookMe manages bookings and this repository is the user service for BookMe
 - Test containers
 - Postgres
 - Docker Compose
+- Hazelcast for caching
 
   
 _Stay tuned for further updates!_

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
+        <!--Caching dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.4.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>iam</groupId>

--- a/src/main/java/iam/userservice/UserServiceApplication.java
+++ b/src/main/java/iam/userservice/UserServiceApplication.java
@@ -2,10 +2,12 @@ package iam.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class UserServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/iam/userservice/config/CacheConfig.java
+++ b/src/main/java/iam/userservice/config/CacheConfig.java
@@ -1,0 +1,24 @@
+package iam.userservice.config;
+
+import com.hazelcast.core.HazelcastInstance;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import static iam.userservice.service.UserService.USERS;
+
+
+@Configuration
+public class CacheConfig {
+    private final HazelcastInstance hazelcastInstance;
+    private final CacheListener cacheListener;
+
+    public CacheConfig(HazelcastInstance hazelcastInstance, CacheListener cacheListener) {
+        this.hazelcastInstance = hazelcastInstance;
+        this.cacheListener = cacheListener;
+    }
+
+    @PostConstruct
+    public void configureCacheListener() {
+        hazelcastInstance.getMap(USERS).addEntryListener(cacheListener, true);
+    }
+}

--- a/src/main/java/iam/userservice/config/CacheListener.java
+++ b/src/main/java/iam/userservice/config/CacheListener.java
@@ -1,0 +1,60 @@
+package iam.userservice.config;
+
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.EntryListener;
+import com.hazelcast.map.MapEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static iam.userservice.service.UserService.USERS;
+
+@Component
+@Slf4j
+public class CacheListener implements EntryListener<Object, Object> {
+
+    @Override
+    public void entryAdded(EntryEvent<Object, Object> entryEvent) {
+        logEntryEvent("has been added", entryEvent);
+    }
+
+    @Override
+    public void entryEvicted(EntryEvent<Object, Object> entryEvent) {
+        logEntryEvent("has been evicted", entryEvent);
+    }
+
+    @Override
+    public void entryExpired(EntryEvent<Object, Object> entryEvent) {
+        logEntryEvent("has expired", entryEvent);
+    }
+
+    @Override
+    public void entryRemoved(EntryEvent<Object, Object> entryEvent) {
+        logEntryEvent("has been removed", entryEvent);
+    }
+
+    @Override
+    public void entryUpdated(EntryEvent<Object, Object> entryEvent) {
+        logEntryEvent("has been updated", entryEvent);
+    }
+
+    @Override
+    public void mapCleared(MapEvent mapEvent) {
+        log.info("Cache has been cleared: {}", mapEvent.getName());
+    }
+
+    @Override
+    public void mapEvicted(MapEvent mapEvent) {
+        log.info("Cache has been evicted: {}", mapEvent.getName());
+    }
+
+    private void logEntryEvent(String action, EntryEvent<Object, Object> event) {
+        String keyType = USERS.equals(event.getName()) ? "key= userId" : "key";
+        log.info("Cache entry {} [map= '{}', {} '{}']",
+                action,
+                event.getName(),
+                keyType,
+                event.getKey());
+    }
+
+
+}

--- a/src/main/resources/hazelcast-prod.yaml
+++ b/src/main/resources/hazelcast-prod.yaml
@@ -1,0 +1,11 @@
+hazelcast:
+  # Adding cluster-name as an extra security measure to prevent accidental joining
+  # of different environments (dev/qa/prod) even if they share the same network
+  cluster-name: prod-cluster
+  network:
+    join:
+      multicast:
+        enabled: false
+      tcp-ip:
+        enabled: true
+#        members: [10.0.0.1, 10.0.0.2] # Explicitly list member IPs

--- a/src/main/resources/hazelcast.yaml
+++ b/src/main/resources/hazelcast.yaml
@@ -1,0 +1,13 @@
+hazelcast:
+  network:
+    join:
+      multicast:
+        enabled: true # Hazelcast nodes will use multicast to automatically discover other nodes in the same network
+  map:
+    users:
+      max-idle-seconds: 1800  # Entries expire if not accessed for 30 minutes
+      time-to-live-seconds: 3600  # Maximum lifetime of 1 hour
+      eviction:
+        size: 1000  # Optional: Maximum number of entries
+        max-size-policy: PER_NODE # Each Hazelcast node maintains its own size limit
+        eviction-policy: LRU # Least Recently Used entries are evicted when the cache reaches its limit or entries expire


### PR DESCRIPTION
### Details:
- Added Hazelcast configuration for distributed caching across multiple nodes
- Configured cache settings with 30-minute idle timeout and 1h TTL
- Implemented cache listeners for monitoring and logging cache events
- Enable multicast for node discovery and disable in production

### Implementation:
- Write-through caching pattern using Spring Cache annotations
- Cache operations: @Cacheable for reads, @CachePut for updates, @CacheEvict for deletes
- Automatic cache invalidation through TTL and idle timeout
- Cache event logging for monitoring and debugging