### PR TITLE
fix(swagger): remove conflicting swagger-annotations dependency to resolve NoSuchMethodError

### DIFF
--- a/k8s/user-app.yaml
+++ b/k8s/user-app.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: user-deployment
+  name: user-app
   labels:
     app: user-app
 spec:
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: user-service
-          image: isaacafrifa/bm-user-service:0.0.1-SNAPSHOT-20250108-2033
+          image: isaacafrifa/bm-user-service:0.0.1-SNAPSHOT-20250518-2125
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -88,19 +88,28 @@ spec:
                 configMapKeyRef:
                   name: infra-config
                   key: MANAGEMENT_ZIPKIN_TRACING_ENDPOINT
+         # Lower resources ideal for local dev. Update when doing heavy processing or caching.
+          resources:
+            requests:
+              memory: "300Mi"
+              cpu: "200m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+        # Lower resource memory may lead to slow boot (~60s+); adjust readiness/liveness probes accordingly
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 120  # Gives app plenty of time to start
+            periodSeconds: 10  # Checks every 10 seconds
+            failureThreshold: 3 # Restarts after 3 failures (30 seconds)
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
-          # add resource limits and requests later
+            initialDelaySeconds: 30 # Shorter delay - starts checking sooner
+            periodSeconds: 5  # More frequent checks
 
 ---
 

--- a/k8s/user-db.yaml
+++ b/k8s/user-db.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: user-db
-          image: postgres:16.1
+          image: postgres:16.1-alpine # Lightweight Alpine-based image, perfect for local dev where minimal resource usage is required
           env:
             - name: POSTGRES_USER
               valueFrom:
@@ -36,13 +36,14 @@ spec:
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgres-data
+       # Small, conservative resource values — enough for this basic case
           resources:
             requests:
-              cpu: "200m"
-              memory: "512Mi"
+              memory: "150Mi"
+              cpu: "100m"
             limits:
-              cpu: "500m"
-              memory: "1Gi"
+              memory: "300Mi"
+              cpu: "200m"
       volumes:
         - name: postgres-data # matches volumeMounts name above
           persistentVolumeClaim:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>iam</groupId>
@@ -106,14 +106,9 @@
         </dependency>
         <!-- openapi spec -->
         <dependency>
-            <groupId>io.swagger.core.v3</groupId>
-            <artifactId>swagger-annotations</artifactId>
-            <version>2.2.22</version>
-        </dependency>
-        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.5.0</version>
+            <version>2.8.8</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools</groupId>

--- a/src/main/java/iam/userservice/exception/ExceptionController.java
+++ b/src/main/java/iam/userservice/exception/ExceptionController.java
@@ -52,8 +52,10 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, @NonNull HttpHeaders headers, @NonNull HttpStatusCode status, WebRequest request) {
-        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
-                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+        List<String> errors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + " " + error.getDefaultMessage())
                 .toList();
         String errorString = String.join(", ", errors);
         APIError apiError = new APIError(errorString, extractPath(request.getDescription(false)));


### PR DESCRIPTION
The project was failing to serve the OpenAPI spec at /v3/api-docs due to a runtime
`NoSuchMethodError` caused by an incompatible version of `swagger-annotations` (v2.2.22).
Springdoc OpenAPI 2.x internally manages its compatible Swagger dependencies, and
having an explicit `swagger-annotations` dependency led to version conflicts.

Removing the direct dependency ensures version alignment with Springdoc (v2.8.8),
fixing the API documentation endpoint and enabling proper aggregation through the Gateway.

### Additional Changes:
- Updated the resource limits and requests in the user-app and user-db yaml files
- Updated the MethodArgumentNotValidException handler in the Exception Controller class